### PR TITLE
revert: "chore: make everything linguist detectable"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* linguist-detectable=true
+**/*.md linguist-detectable=true


### PR DESCRIPTION
**Please describe what the pull request is about, and what this aims to do:**
Apparently it confuses people since GitHub detects lots of files being YAML and not markdown, it was useful back then when there were less files though.

**Details on why this pull request should be merged:**
It is less confusing.

**Any alternative pull requests or issues that work on this:**
N/A 

**Additional details:**
N/A